### PR TITLE
corrected one Hot calculation

### DIFF
--- a/ppo_deterministic_v2.py
+++ b/ppo_deterministic_v2.py
@@ -272,7 +272,7 @@ class Agent:
         batch_old_prediction = self.get_old_prediction(batch_s)
         #one-hot the actions. Actions will be the target for actor.
         batch_a_final = np.zeros(shape=(len(batch_a), self.action_n))
-        batch_a_final[:, batch_a.flatten()] = 1
+        batch_a_final[np.arange(len(batch_a)), batch_a.flatten()] = 1
 
         #commit training
         self.actor_network.fit(x=[batch_s, batch_advantage, batch_old_prediction], y=batch_a_final, verbose=0)


### PR DESCRIPTION
Hi,
if you have following Array:
array = np.array([
[0, 0, 0],
[0, 0, 0],
[0, 0, 0],
[0, 0, 0]
])

and you execute the code:
array[:, [0, 2, 0, 2]] = 1
you get back following Array:
[1, 0, 1],
[1, 0, 1],
[1, 0, 1],
[1, 0, 1],

and not (what you might have expected and want):
[1, 0, 0],
[0, 0, 1],
[1, 0, 0],
[0, 0, 1]
to get the wanted Array, you can for example do:
array[np.arange(len(array)), [0, 2, 0, 2]] = 1

with your current Implementation it is very likely, that your "one_hot" Array in train_network named batch_a_final just has an 1 in every element! and since that's the one hot Array used for training/loss Calculation this is really screwing up your whole Network!